### PR TITLE
POSIX対応の改善

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 cmake_minimum_required(VERSION 3.13)
 option(USE_ICONV "Use iconv for converting Shift-JIS to UTF-8." ON)
 
+project(run68 C)
+
 #add_definitions(-DFNC_TRACE -DENV_FROM_INI)
 add_definitions(-DENV_FROM_INI)
 
 if(USE_ICONV)
+    find_package(Iconv REQUIRED)
     add_definitions(-DUSE_ICONV)
 else()
 endif()
-
-
-project(run68 C)
 
 if (EMSCRIPTEN)
 set(CMAKE_EXE_LINKER_FLAGS "--embed-file ./fs@ -sFORCE_FILESYSTEM")
@@ -58,10 +58,8 @@ add_executable(run68 ${SRC})
 set(LIBS m) # math lib
 
 if(USE_ICONV)
-
-  if(APPLE)
-    set(LIBS ${LIBS} "iconv")
-  endif()
+  include_directories(${Iconv_INCLUDE_DIRS})
+  set(LIBS ${LIBS} ${Iconv_LIBRARIES})
 endif()
 
 target_link_libraries(run68 PUBLIC ${LIBS})

--- a/src/doscall.c
+++ b/src/doscall.c
@@ -70,9 +70,6 @@
   #include <dos.h>
   #include <direct.h>
   #include <io.h>
-#elif defined(__APPLE__) || defined(__EMSCRIPTEN__)
-  #include <time.h>
-  #include <dirent.h>
 #else
   #include <time.h>
   #include <dirent.h>
@@ -136,7 +133,7 @@ static Long gets2( char *, int );
 
 Long Getenv_common(const char *name_p, char *buf_p);
 
-#if defined(__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+#if !defined(WIN32) && !defined(DOSX)
 void CloseHandle( FILE* fp ) {
 	fclose( fp );
 }
@@ -368,7 +365,7 @@ int dos_call( UChar code )
 #elif defined(DOSX)
 		_dos_write( fileno(finfo[ 1 ].fh), data_ptr,
 					(unsigned)len, &drv );
-#elif defined(__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+#else
 //		_dos_write( fileno(finfo[ 1 ].fh), data_ptr, (unsigned)len, &drv );
 #if defined (USE_ICONV)
 	{
@@ -388,8 +385,6 @@ int dos_call( UChar code )
 #else
 	printf("%s", data_ptr);
 #endif
-#else
-		printf("DOSCALL:PRINT not implemented yet.\n");
 #endif
 		/* printf( "%s", data_ptr ); */
 		rd [ 0 ] = 0;
@@ -1573,7 +1568,7 @@ static Long Create( char *p, short atr )
 	int    len;
 	
 	
-#if defined(__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+#if !defined(WIN32) && !defined(DOSX)
 	char* name = p;
 	int namelen = strlen(name);
 	for (int i=0;i<namelen;++i) {
@@ -1719,7 +1714,7 @@ static Long Open( char *p, short mode )
 	Long ret;
 	Long i;
 
-#if defined(__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+#if !defined(WIN32) && !defined(DOSX)
 	char* name = p;
 	int namelen = strlen(name);
 	for (int i=0;i<namelen;++i) {
@@ -1985,15 +1980,10 @@ static Long Write( short hdl, Long buf, Long len )
 	}
 	if (finfo [ hdl ].fh == stdout)
 	  fflush( stdout );
-#elif defined(__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
-	write_len = fwrite( write_buf, 1, len, finfo [ hdl ].fh );
-	if (finfo [ hdl ].fh == stdout)
-	  fflush( stdout );
 #else
 	write_len = fwrite( write_buf, 1, len, finfo [ hdl ].fh );
 	if (finfo [ hdl ].fh == stdout)
 	  fflush( stdout );
-//	#error NOTIMPLEMENTED
 #endif
 
 	return( write_len );
@@ -2553,8 +2543,6 @@ static Long Nfiles( Long buf )
 	strncpy(&buf_ptr[30], f_data.cFileName, 22);
 	buf_ptr[30+22] = 0;
 
-#elif defined(__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
-	printf("DOSCALL NFILES:not defined yet %s %d\n", __FILE__, __LINE__ );
 #else
 	printf("DOSCALL NFILES:not defined yet %s %d\n", __FILE__, __LINE__ );
 #endif
@@ -2567,7 +2555,7 @@ static Long Nfiles( Long buf )
  */
 static Long Filedate( short hdl, Long dt )
 {
-#if defined(__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+#if !defined(WIN32) && !defined(DOSX)
 	printf("DOSCALL FILEDATE:not defined yet %s %d\n", __FILE__, __LINE__ );
 #else
 #if defined(WIN32)

--- a/src/iocscall.c
+++ b/src/iocscall.c
@@ -26,8 +26,7 @@
   #include <windows.h>
 #elif defined(DOSX)
   #include <dos.h>
-#elif defined(__APPLE__)
-#else
+#elif defined(__linux__)
   #include <sys/sysinfo.h>
 #endif
 
@@ -177,11 +176,11 @@ int iocs_call()
 			ul = time( NULL );
 			rd [ 0 ] = (ul % (60 * 60 * 24)) * 100;
 			rd [ 1 ] = ((ul / (60 * 60 * 24)) & 0xFFFF);
-#elif defined(__APPLE__) || defined(__EMSCRIPTEN__)
+#elif !defined(__linux__)
 			ul = time( NULL );
 			rd [ 0 ] = (ul % (60 * 60 * 24)) * 100;
 			rd [ 1 ] = ((ul / (60 * 60 * 24)) & 0xFFFF);
-#else
+#else //__linux__
             {
 				struct sysinfo info;
 				sysinfo(&info);

--- a/src/load.c
+++ b/src/load.c
@@ -137,7 +137,7 @@ ErrorRet:
     return NULL;
 }
 
-#if defined(__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+#if !defined(WIN32) && !defined(DOSX)
   #define PATH_DELIMITER ':'
 #else
   #define PATH_DELIMITER ';'

--- a/src/run68.c
+++ b/src/run68.c
@@ -99,7 +99,7 @@ HANDLE stdin_handle;
 /* アボート処理のためのジャンプバッファ */
 jmp_buf jmp_when_abort;
 
-#if defined (__APPLE__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+#if !defined(WIN32) && !defined(DOSX)
 char *strlwr(char *str)
 {
   unsigned char *p = (unsigned char *)str;


### PR DESCRIPTION
お邪魔いたします。OpenBSDでのビルドを行えるようにすべく、改良を加えました。良ければ取り込んでください。

- #if defined～でターゲットを列挙するのは今後のメンテナンスがやりにくくなるため、DOSX/WIN32もしくはそれ以外とざっくり分け、メンテナンスしやすくなるように整理しています
- CMakeの機能を使用し、iconvライブラリの所在を自動検出するようにしています

現時点において、Linux/OpenBSDでのビルドを確認しています。FreeBSD/NetBSD/DragonFlyBSDにおいてはgcvt()/fcvt()未実装につき、snprintf()による書き直しが必要になります。 