### PR TITLE
msys の utf8 対応、および非windows環境で相対パスで起動すると run68.ini が読めない問題の修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,14 @@
 cmake_minimum_required(VERSION 3.13)
+execute_process(COMMAND uname OUTPUT_VARIABLE uname) # for detecting msys
 option(USE_ICONV "Use iconv for converting Shift-JIS to UTF-8." ON)
 
 #add_definitions(-DFNC_TRACE -DENV_FROM_INI)
 add_definitions(-DENV_FROM_INI)
 
 if(USE_ICONV)
+  if (NOT(uname MATCHES "^MSYS" OR uname MATCHES "^MINGW"))
     add_definitions(-DUSE_ICONV)
-else()
+  endif()
 endif()
 
 
@@ -19,6 +21,10 @@ endif()
 
 set(CMAKE_C_FLAGS 
     "-O3 -Wno-int-conversion -Wno-return-type -Wno-switch -Wno-implicit-function-declaration -Wno-format -Wno-invalid-source-encoding -Wno-pointer-integer-compare -Wno-int-to-pointer-cast -Wno-pointer-sign -Wno-incompatible-pointer-types")
+
+if (uname MATCHES "^MSYS" OR uname MATCHES "^MINGW")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --exec-charset=cp932") # To support utf-8 (cp932 is not a mistake. it works fine.)
+endif()
 
 set(SRC 
     src/ansicolor-w32.c
@@ -58,13 +64,7 @@ add_executable(run68 ${SRC})
 set(LIBS m) # math lib
 
 if(USE_ICONV)
-
   if(APPLE)
-    set(LIBS ${LIBS} "iconv")
-  endif()
-
-  execute_process(COMMAND uname OUTPUT_VARIABLE uname)
-  if (uname MATCHES "^MSYS" OR uname MATCHES "^MINGW")
     set(LIBS ${LIBS} "iconv")
   endif()
 endif()

--- a/src/getini.c
+++ b/src/getini.c
@@ -38,7 +38,8 @@ static void chomp(char *buf)
 
 void	read_ini(char *path, char *prog)
 {
-	char	buf[1024];
+	char	dir[1024] = {0};
+	char	buf[1024] = {0};
 	char	sec_name[MAX_PATH];
 	FILE	*fp;
 	int	flag = TRUE;
@@ -58,12 +59,15 @@ void	read_ini(char *path, char *prog)
     /* まずはファイル名を取得する。*/
     if ((p = strrchr(path, '\\')) != NULL)
     {
+        memcpy(dir, path, p - path + 1);
         strcpy(buf, p+1);
     } else if ((p = strrchr(path, '/')) != NULL)
     {
+        memcpy(dir, path, p - path + 1);
         strcpy(buf, p+1);
     } else if ((p = strrchr(path, ':')) != NULL)
     {
+        memcpy(dir, path, p - path + 1);
         strcpy(buf, p+1);
     } else
     {
@@ -81,19 +85,8 @@ void	read_ini(char *path, char *prog)
     {
         return; /* .exe以外の拡張子はないと思う。*/
     }
-#if defined(WIN32)
-    /* 次に、フルパス名を得る。*/
-    l = SearchPath(
-        NULL,       // address of search path 
-        buf,        // address of filename 
-        NULL,       // address of extension 
-        MAX_PATH,   // size, in characters, of buffer 
-        path,       // address of buffer for found filename 
-        &p          // address of pointer to file component 
-    );
-#else
-    snprintf(path, MAX_PATH, "%s", buf);
-#endif
+    /* ディレクトリ名とファイル名を結合する。*/
+	snprintf(path, MAX_PATH, "%s%s", dir, buf);
 #if defined(_DEBUG)
     printf("INI:%s\n", path);
 #endif


### PR DESCRIPTION
run68mac の問題を修正しましたので、プルリクを作成いたしました。
もし差支えなければ取り込んでいただけないでしょうか。
よろしくお願いいたします。


・msys の utf8 対応

	これまでの run68mac の実装では、X68K コマンドから出力される文字列は SJIS で、
	run68 自身が出力する文字列は UTF8 になっていました。
	msys のコンソールはこれを SJIS -> UTF8 変換しようとして、文字化けを起こしていました。

	msys 上で utf8 対応を正しく行う方法を調べた結果、コンソール出力はすべて SJIS とし、
	mintty に UTF8 変換させるのが現状可能な妥当な方法ということがわかりました。
	ipconfig などの windows コマンドが SJIS で出してくるので、msys は（苦肉の策として）
	このスタイルを採用しているようです。run68 もこの仕組みに乗ることで文字化け問題を解決できます。

	これを踏まえ、以下の２点を修正を適用しました。

	１）msys ビルドルールから iconv の処理を除去（CMakeLists.txt の修正のみで可能）
	２）run68mac の msys ビルドの、実行ファイル内文字列を SJIS 化（コンパイルオプション指定のみで可能）


・windows 以外の環境で run68 を相対パス起動すると run68.ini が認識できない問題の修正

	WSL 上で run68 を相対パス起動すると run68.ini が認識できないという報告がありました。
	linux でも同様の問題が再現していました。
	mac は未確認ですが linux と同様の問題が発生していると考えられます。

	run68 の実装を確認したところ、windows 以外の環境で ini ファイルのパス文字列作成部に問題がありました。

	この問題を修正するため、以下の２点を修正を適用しました。
	１）argv[0] 由来の文字列を、ディレクトリ名部分とファイル名部分に分離する
	２）ini ファイル名にディレクトリ名を結合して ini ファイルのパスとする


具体的な内容はコード差分をご参照下さい。

linux/WSL/msys 上で動作確認が取れています。mac は手元に環境がないため未確認です。
