### PR TITLE
^Dでデバッガを抜けられるようにしました。

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -133,7 +133,15 @@ RUN68_COMMAND debugger(BOOL running)
         char *argv[MAX_LINE];
         int argc;
         fprintf(stderr, "%s", PROMPT);
-        fgets(line, MAX_LINE, stdin);
+        if (fgets(line, MAX_LINE, stdin) == NULL)
+        {
+            if (feof(stdin) || ferror(stdin))
+            {
+                fputs("quit\n", stderr);
+                cmd = RUN68_COMMAND_QUIT;
+                goto EndOfLoop;
+            }
+        }
         cmd = analyze(line, &argc, argv);
         if (argc == 0)
         {


### PR DESCRIPTION
デバッガのプロンプトで^Dを入力するとその後プロンプトが表示され続け入力不能となるため、代わりに^Dをquitコマンドと同等の入力として扱うようにしてみました。