### PR TITLE
fix implicit int warning

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -463,7 +463,7 @@ const EXEC_INSTRUCTION_INFO *OPBuf_getentry(int no)
     戻り値：
       なし。
 */
-void OPBuf_display(n)
+void OPBuf_display(int n)
 {
     int max = OPBuf_numentries();
     int i;


### PR DESCRIPTION
Recent compilers warn about implicit int.