### PR TITLE
Make exec.c compile with modern C compilers

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -463,7 +463,7 @@ const EXEC_INSTRUCTION_INFO *OPBuf_getentry(int no)
     戻り値：
       なし。
 */
-void OPBuf_display(n)
+void OPBuf_display(int n)
 {
     int max = OPBuf_numentries();
     int i;


### PR DESCRIPTION
run68 already depends on C99 features here and there, but exec.c still relies on implicit int assumption on OPBuf_display's argument. This is not valid on C99 and later any more, and recent compilers cannot compile it.