### PR TITLE
Add -fsigned-char

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 
 set(CMAKE_C_FLAGS 
-    "-O3 -Wno-int-conversion -Wno-return-type -Wno-switch -Wno-implicit-function-declaration -Wno-format -Wno-invalid-source-encoding -Wno-pointer-integer-compare -Wno-int-to-pointer-cast -Wno-pointer-sign -Wno-incompatible-pointer-types")
+    "-O3 -fsigned-char -Wno-int-conversion -Wno-return-type -Wno-switch -Wno-implicit-function-declaration -Wno-format -Wno-invalid-source-encoding -Wno-pointer-integer-compare -Wno-int-to-pointer-cast -Wno-pointer-sign -Wno-incompatible-pointer-types")
 
 set(SRC 
     src/ansicolor-w32.c


### PR DESCRIPTION
`char` type could be `unsigned char` or `signed char` depending on CPU architectures. It's `unsigned char` by default on aarch32 architectures, though it's `signed char` on intel architectures. This causes many unexpected behaviors on run68, and we need to specify `-fsigned-char` flag explicitly to make the behavior compatible on all platforms.